### PR TITLE
Make /day set the time to the beginning of the day

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,7 @@ minetest.register_chatcommand ("day", {
 	params = "",
 	description = "Sets the time to day",
 	func = function ()
-		minetest.set_timeofday(0.5)
+		minetest.set_timeofday(6200 / 27000)
 	end
 })
 


### PR DESCRIPTION
This means that I have to execute it less often :P

I don't want to _disable_ the day / night cycle - it's useful sometimes! Sometimes I just want to work in the daytime in peace.....